### PR TITLE
Use without jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ go-license-scraper collects go module license by scraping http://pkg.go.dev (or 
 
 ## Prerequisite
 
-- [jq](https://stedolan.github.io/jq/)
+- [Node.js](https://nodejs.org/)
+- Your Golang project
 
 ## Install
 
@@ -16,5 +17,5 @@ $ npm install -g go-license-scraper
 
 ```
 $ cd path/to/your/directory/of/go.mod
-$ go list -m -json all | jq -c 'select(.Main != true)' | go-license-scraper | jq -r '[.path, .version, .license, .url] | @csv'
+$ go list -m -json all | go-license-scraper
 ```

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -1,4 +1,4 @@
-import {ModVersion} from './ModVersion';
+import {Module} from './Module';
 import {UrlAndSelector} from './UrlAndSelector';
 
 const version0 = /^v0\.0\.0-/;
@@ -8,7 +8,7 @@ const pkgGoDevSelector =
 const githubSelector = 'h3:has-text("License") + .mt-3 a';
 
 export class Builder {
-  constructor(readonly modVersion: ModVersion) {}
+  constructor(readonly modVersion: Module) {}
 
   get path(): string {
     return this.modVersion.path;

--- a/src/Formatter.ts
+++ b/src/Formatter.ts
@@ -1,0 +1,11 @@
+import {License} from './License';
+
+export interface Formatter {
+  format(v: License): string;
+}
+
+export class CsvFormatter implements Formatter {
+  format(v: License): string {
+    return [v.path, v.version, v.license, v.url].map(i => `"${i}"`).join(',');
+  }
+}

--- a/src/ModVersion.ts
+++ b/src/ModVersion.ts
@@ -1,6 +1,12 @@
 export type ModVersion = {
-  readonly path: string;
-  readonly version: string;
+  readonly path: string; // "Path"
+  readonly version: string; // "Version"
+  readonly main: boolean; // "Main"
+  // readonly time: string; // "Time"
+  // readonly indirect: boolean; // "Indirect"
+  // readonly dir: string; // "Dir"
+  // readonly goMod: string; // "GoMod"
+  // readonly goVersion: string; // "GoVersion"
 };
 
 class ModVersionCompanion {
@@ -8,7 +14,8 @@ class ModVersionCompanion {
     const d = JSON.parse(line);
     const path = d['Path'] as string;
     const version = d['Version'] as string;
-    return {path, version};
+    const main = (d['Main'] || false) as boolean;
+    return {path, version, main};
   }
 }
 

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -1,4 +1,4 @@
-export type ModVersion = {
+export type Module = {
   readonly path: string; // "Path"
   readonly version: string; // "Version"
   readonly main: boolean; // "Main"
@@ -9,8 +9,8 @@ export type ModVersion = {
   // readonly goVersion: string; // "GoVersion"
 };
 
-class ModVersionCompanion {
-  parse(line: string): ModVersion {
+class ModuleCompanion {
+  parse(line: string): Module {
     const d = JSON.parse(line);
     const path = d['Path'] as string;
     const version = d['Version'] as string;
@@ -19,4 +19,4 @@ class ModVersionCompanion {
   }
 }
 
-export const ModVersion = new ModVersionCompanion();
+export const Module = new ModuleCompanion();

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -1,7 +1,7 @@
 import {chromium, Page} from 'playwright';
 import {Builder} from './Builder';
 import {License} from './License';
-import {ModVersion} from './ModVersion';
+import {Module} from './Module';
 import {UrlAndSelector} from './UrlAndSelector';
 
 export class Scraper {
@@ -56,7 +56,7 @@ export class Scraper {
     );
   }
 
-  async process(mod: ModVersion): Promise<License> {
+  async process(mod: Module): Promise<License> {
     const patterns = new Builder(mod).patterns;
     const r = await this.getLicenseAndUrl(patterns);
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import {CsvFormatter} from './Formatter';
 import {readAndWrite} from './readAndWrite';
 import {Scraper} from './Scraper';
 
@@ -11,6 +12,7 @@ process.stdin.on('data', chunk => {
 
 process.stdin.on('end', () => {
   Scraper.process(async scraper => {
+    const formatter = new CsvFormatter();
     const lines = input_string.split('}\n{').map(i => {
       let r = i.trim();
       if (!r.startsWith('{')) r = '{' + r;
@@ -18,7 +20,7 @@ process.stdin.on('end', () => {
       return r;
     });
     for (const line of lines) {
-      await readAndWrite(scraper, line, process.stdout);
+      await readAndWrite(scraper, line, formatter, process.stdout);
     }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,12 @@ process.stdin.on('data', chunk => {
 
 process.stdin.on('end', () => {
   Scraper.process(async scraper => {
-    const lines = input_string.split('\n');
+    const lines = input_string.split('}\n{').map(i => {
+      let r = i.trim();
+      if (!r.startsWith('{')) r = '{' + r;
+      if (!r.endsWith('}')) r = r + '}';
+      return r;
+    });
     for (const line of lines) {
       await readAndWrite(scraper, line, process.stdout);
     }

--- a/src/readAndWrite.ts
+++ b/src/readAndWrite.ts
@@ -1,9 +1,11 @@
 import {Scraper} from './Scraper';
 import {Module} from './Module';
+import {Formatter} from './Formatter';
 
 export const readAndWrite = async (
   scraper: Scraper,
   line: string,
+  formatter: Formatter,
   dest: NodeJS.WriteStream
 ): Promise<void> => {
   if (!line.trim()) return;
@@ -11,7 +13,8 @@ export const readAndWrite = async (
   if (mod.main) return; // Main module is not targeted
   try {
     const license = await scraper.process(mod);
-    dest.write(JSON.stringify(license));
+    const output = formatter.format(license);
+    dest.write(output);
     dest.write('\n');
   } catch (
     err: any // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/readAndWrite.ts
+++ b/src/readAndWrite.ts
@@ -8,6 +8,7 @@ export const readAndWrite = async (
 ): Promise<void> => {
   if (!line.trim()) return;
   const mod = ModVersion.parse(line);
+  if (mod.main) return; // Main module is not targeted
   try {
     const license = await scraper.process(mod);
     dest.write(JSON.stringify(license));

--- a/src/readAndWrite.ts
+++ b/src/readAndWrite.ts
@@ -1,5 +1,5 @@
 import {Scraper} from './Scraper';
-import {ModVersion} from './ModVersion';
+import {Module} from './Module';
 
 export const readAndWrite = async (
   scraper: Scraper,
@@ -7,7 +7,7 @@ export const readAndWrite = async (
   dest: NodeJS.WriteStream
 ): Promise<void> => {
   if (!line.trim()) return;
-  const mod = ModVersion.parse(line);
+  const mod = Module.parse(line);
   if (mod.main) return; // Main module is not targeted
   try {
     const license = await scraper.process(mod);


### PR DESCRIPTION
- Before this PR, requires jq to filter input and format output
- After this PR, doesn't require jq any more

You can use go-license-scraper like this:

```
go list -m -json all | go-license-scraper
```