### PR TITLE
Use installed Chrome browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ go-license-scraper collects go module license by scraping http://pkg.go.dev (or 
 ## Prerequisite
 
 - [Node.js](https://nodejs.org/)
+- [Google Chrome](https://www.google.com/chrome/)
 - Your Golang project
 
 ## Install
@@ -19,3 +20,9 @@ $ npm install --location=global go-license-scraper
 $ cd path/to/your/directory/of/go.mod
 $ go-license-scraper PATH/TO/LICENSES.csv
 ```
+
+### Chrome Canary or Microsoft Edge
+
+Set browser channel to environment variable `BROWSER_CHANNEL`.
+If you want to use Microsoft Edge instead of Chrome, set `msedge`.
+See https://playwright.dev/docs/api/class-testoptions#test-options-channel for more details.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go-license-scraper collects go module license by scraping http://pkg.go.dev (or 
 ## Install
 
 ```
-$ npm install -g go-license-scraper
+$ npm install --location=global go-license-scraper
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fast-csv/parse": "^4.3.6",
-        "playwright": "^1.15.0"
+        "playwright-core": "^1.22.0"
       },
       "bin": {
         "go-license-scraper": "bin/go-license-scraper.js"
@@ -2675,21 +2675,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.22.1.tgz",
-      "integrity": "sha512-pn4dvphQdL3zTgI+xfqkTL3HK1xbtQz+zjJxzyhwKLDxMNuAH7/NCm75auWbYLyssdnvApznujwrQuJvqXTKUw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "playwright-core": "1.22.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/playwright-core": {
@@ -5608,14 +5593,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
-    },
-    "playwright": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.22.1.tgz",
-      "integrity": "sha512-pn4dvphQdL3zTgI+xfqkTL3HK1xbtQz+zjJxzyhwKLDxMNuAH7/NCm75auWbYLyssdnvApznujwrQuJvqXTKUw==",
-      "requires": {
-        "playwright-core": "1.22.1"
-      }
     },
     "playwright-core": {
       "version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/akm/go-license-scraper#readme",
   "dependencies": {
     "@fast-csv/parse": "^4.3.6",
-    "playwright": "^1.15.0"
+    "playwright-core": "^1.22.0"
   },
   "devDependencies": {
     "@types/node": "^14.11.2",

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -6,13 +6,16 @@ import {Processor} from './Processor';
 import {UrlAndSelector} from './UrlAndSelector';
 
 export class Scraper implements Processor {
-  static async process(f: {(scraper: Scraper): Promise<void>}): Promise<void> {
+  static async process(
+    excludedModoules: string[],
+    f: {(scraper: Scraper): Promise<void>}
+  ): Promise<void> {
     // https://playwright.dev/docs/api/class-testoptions#test-options-channel
     const browserChannel = process.env.BROWSER_CHANNEL || 'chrome';
     const browser = await chromium.launch({channel: browserChannel});
     const page = await browser.newPage();
 
-    const scraper = new Scraper(page);
+    const scraper = new Scraper(page, excludedModoules);
     try {
       await f(scraper);
     } finally {
@@ -20,7 +23,10 @@ export class Scraper implements Processor {
     }
   }
 
-  constructor(private readonly page: Page) {}
+  constructor(
+    private readonly page: Page,
+    readonly excludedModoules: string[]
+  ) {}
 
   async scrape(url: string, selector: string): Promise<string | undefined> {
     await this.page.goto(url);
@@ -60,6 +66,15 @@ export class Scraper implements Processor {
   }
 
   async process(mod: Module): Promise<License> {
+    if (this.excludedModoules.includes(mod.path)) {
+      return {
+        path: mod.path,
+        version: '',
+        license: '(included)',
+        url: '',
+      };
+    }
+
     const patterns = new Builder(mod).patterns;
     const r = await this.getLicenseAndUrl(patterns);
     return {

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -1,4 +1,4 @@
-import {chromium, Page} from 'playwright';
+import {chromium, Page} from 'playwright-core';
 import {Builder} from './Builder';
 import {License} from './License';
 import {Module} from './Module';

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -7,7 +7,9 @@ import {UrlAndSelector} from './UrlAndSelector';
 
 export class Scraper implements Processor {
   static async process(f: {(scraper: Scraper): Promise<void>}): Promise<void> {
-    const browser = await chromium.launch();
+    // https://playwright.dev/docs/api/class-testoptions#test-options-channel
+    const browserChannel = process.env.BROWSER_CHANNEL || 'chrome';
+    const browser = await chromium.launch({channel: browserChannel});
     const page = await browser.newPage();
 
     const scraper = new Scraper(page);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {spawn} from 'child_process';
+import {spawn, execSync, execFileSync} from 'child_process';
 import {createWriteStream, existsSync} from 'fs';
 
 import {CsvFormatter} from './Formatter';
@@ -21,6 +21,11 @@ const main = async () => {
     ? await formatter.load(csvPath)
     : new Cache();
 
+  // const includedPackages =
+  const excludedModoules = execFileSync('go', ['list'], {encoding: 'utf8'})
+    .split('\n')
+    .filter(i => i.trim());
+
   const dest = createWriteStream(csvPath);
 
   const golist = spawn('go', ['list', '-m ', '-json', 'all'], {shell: true});
@@ -32,7 +37,7 @@ const main = async () => {
   });
 
   golist.stdout.on('end', () => {
-    Scraper.process(async scraper => {
+    Scraper.process(excludedModoules, async scraper => {
       const processor = new CacheProcessor(scraper, cache);
       const lines = input_string.split('}\n{').map(i => {
         let r = i.trim();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {spawn, execSync, execFileSync} from 'child_process';
+import {spawn, execFileSync} from 'child_process';
 import {createWriteStream, existsSync} from 'fs';
 
 import {CsvFormatter} from './Formatter';


### PR DESCRIPTION
- Use installed browser
    - Default Google Chrome
    - Set environment variable `BROWSER_CHANNEL` to use Chrome Canary or Microsoft Edge.
        - See https://playwright.dev/docs/api/class-testoptions#test-options-channel for more details.
- Skip scraping for application modules
