### PR TITLE
headed mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,55 @@
 {
-  "extends": "./node_modules/gts/"
+  "extends": ["eslint:recommended", "plugin:node/recommended", "prettier"],
+  "plugins": ["node", "prettier"],
+  "rules": {
+    "prettier/prettier": "error",
+    "block-scoped-var": "error",
+    "eqeqeq": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "eol-last": "error",
+    "prefer-arrow-callback": "error",
+    "no-trailing-spaces": "error",
+    "quotes": ["warn", "single", {"avoidEscape": true}],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "describe",
+        "property": "only"
+      },
+      {
+        "object": "it",
+        "property": "only"
+      }
+    ]
+  },
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.tsx"],
+      "parser": "@typescript-eslint/parser",
+      "extends": ["plugin:@typescript-eslint/recommended"],
+      "rules": {
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/no-warning-comments": "off",
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "@typescript-eslint/ban-types": "off",
+        "@typescript-eslint/camelcase": "off",
+        "node/no-missing-import": "off",
+        "node/no-empty-function": "off",
+        "node/no-unsupported-features/es-syntax": "off",
+        "node/no-missing-require": "off",
+        "node/shebang": "off",
+        "no-dupe-class-members": "off",
+        "require-atomic-updates": "off"
+      },
+      "parserOptions": {
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+      }
+    }
+  ]
 }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-  ...require('gts/.prettierrc.json')
-}
+  bracketSpacing: false,
+  singleQuote: true,
+  trailingComma: 'es5',
+  arrowParens: 'avoid',
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-license-scraper",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -38,9 +38,7 @@ export class Scraper implements Processor {
     await this.page.waitForLoadState();
 
     // await page.pause();
-    const license = (
-      await this.page.$eval(selector, el => el.textContent)
-    )?.trim();
+    const license = (await this.page.textContent(selector))?.trim();
     return license;
   }
 

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -12,7 +12,12 @@ export class Scraper implements Processor {
   ): Promise<void> {
     // https://playwright.dev/docs/api/class-testoptions#test-options-channel
     const browserChannel = process.env.BROWSER_CHANNEL || 'chrome';
-    const browser = await chromium.launch({channel: browserChannel});
+    const headless = !(
+      process.env.HEADED === 'true' ||
+      process.env.HEADED === 'on' ||
+      process.env.HEADED === '1'
+    );
+    const browser = await chromium.launch({channel: browserChannel, headless});
     const page = await browser.newPage();
 
     const scraper = new Scraper(page, excludedModoules);

--- a/src/Scraper.ts
+++ b/src/Scraper.ts
@@ -38,8 +38,7 @@ export class Scraper implements Processor {
     await this.page.waitForLoadState();
 
     // await page.pause();
-    const license = (await this.page.textContent(selector))?.trim();
-    return license;
+    return (await this.page.textContent(selector))?.trim();
   }
 
   async getLicenseAndUrl(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES5",
     "lib": ["dom", "esnext"],
     "rootDir": "src",
     "outDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,19 @@
 {
-  "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "lib": ["dom", "esnext"],
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "declaration": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "pretty": true,
+    "sourceMap": true,
+    "strict": true
   },
+  "exclude": ["node_modules"],
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
You can run go-license-scraper with environment variable `HEADED=true`,  `HEADED=on` or `HEADED=1` for headed mode